### PR TITLE
Updated tifgenerator so it can be univerally used

### DIFF
--- a/Src/utils.py
+++ b/Src/utils.py
@@ -32,7 +32,7 @@ def zonal_stats(path_to_shape_file, lon, lat, val):
     return value_means
 
 
-def tifgenerator(outfile, raster_path, df, value='yhat'):
+def tifgenerator(outfile, raster_path, df, value='yhat',aggregate_factor=1,crop=False,minimum_pop=0.3):
     """
     Given a filepath (.tif), a raster for reference and a dataset with i, j and yhat
     it generates a raster.
@@ -41,6 +41,39 @@ def tifgenerator(outfile, raster_path, df, value='yhat'):
     :param df:
     :return:
     """
+    
+    # Aggregate raster per aggregation factor
+    if aggregate_factor > 1:
+        print('INFO: aggregating raster ...')
+        local_raster_path = "../tmp/local_raster.tif"
+        aggregate(raster_path, local_raster_path, aggregate_factor)
+        #change raster path
+        raster_path = local_raster_path
+    
+    #Crop to data
+    if crop:
+        minlat, maxlat, minlon, maxlon = df_boundaries(df, buffer=0.05, lat_col="gpsLatitude", lon_col="gpsLongitude")
+        area = points_to_polygon(minlon, minlat, maxlon, maxlat)
+        
+        # crop raster
+        with rasterio.open(raster_path) as src:
+            out_image, out_transform = mask(src, [area], crop=True)
+            out_meta = src.meta.copy()
+
+        # save the resulting raster
+        out_meta.update({"driver": "GTiff",
+                         "height": out_image.shape[1],
+                         "width": out_image.shape[2],
+                         "transform": out_transform
+                         })
+
+        final_raster = "../tmp/final_raster.tif"
+        with rasterio.open(final_raster, "w", **out_meta) as dest:
+            out_image[out_image < minimum_pop] = dest.nodata
+            dest.write(out_image)
+            list_j, list_i = np.where(dest.read()[0] != dest.nodata)
+        # change raster path
+        raster_path = final_raster
 
     print('-> writing: ', outfile)
     # create empty raster from the original one
@@ -84,59 +117,6 @@ def aggregate(input_rst, output_rst, scale):
     output_gr = input_gr.aggregate(block_size=(scale, scale))
 
     output_gr.to_tiff(output_rst.replace(".tif", ""))
-
-def upscaleBaseRaster(base_raster, aggregate_factor, dataset_df, minimum_pop=0.3, minlat=None, maxlat=None, minlon=None, maxlon=None):
-    """
-    reduce resolution of base raster
-    Args:
-        base_raster: filepath to base raster
-        aggregat_factor: self explantory
-        dataset_df: dataframe of dataset for scoring with GPS coords
-        minimum_pop: population density below which areas are omitted
-    """
-    # WorldPop Raster too fine, aggregate #
-    #if aggregate_factor is None:
-    #    aggregate_factor = config["base_raster_aggregation"][0]
-
-    if aggregate_factor > 1:
-        print('INFO: aggregating raster ...')
-        base_raster = "../tmp/local_raster.tif"
-        aggregate(raster, base_raster, aggregate_factor)
-    else:
-        base_raster = raster
-
-    # ---------------- #
-    # AREA OF INTEREST #
-    # ---------------- #
-    data_cols = dataset_df.columns.values
-
-    # create geometry
-    if (minlat is None) and (maxlat is None) and (minlon is None) and (maxlon is None):
-        minlat, maxlat, minlon, maxlon = df_boundaries(dataset_df, buffer=0.05, lat_col="gpsLatitude", lon_col="gpsLongitude")
-
-    area = points_to_polygon(minlon, minlat, maxlon, maxlat)
-
-    # crop raster
-    with rasterio.open(base_raster) as src:
-        out_image, out_transform = mask(src, [area], crop=True)
-        out_meta = src.meta.copy()
-
-    # save the resulting raster
-    out_meta.update({"driver": "GTiff",
-                     "height": out_image.shape[1],
-                     "width": out_image.shape[2],
-                     "transform": out_transform
-                     })
-
-    final_raster = "../tmp/final_raster.tif"
-    with rasterio.open(final_raster, "w", **out_meta) as dest:
-        out_image[out_image < minimum_pop] = dest.nodata
-        dest.write(out_image)
-        list_j, list_i = np.where(dest.read()[0] != dest.nodata)
-
-    return final_raster
-    
-    
     
 def squaretogeojson(lon, lat, d):
     from math import pi, cos

--- a/Src/utils.py
+++ b/Src/utils.py
@@ -41,6 +41,8 @@ def tifgenerator(outfile, raster_path, df, value='yhat',aggregate_factor=1,crop=
     :param df:
     :return:
     """
+    import rasterio
+    from rasterio.mask import mask
     
     # Aggregate raster per aggregation factor
     if aggregate_factor > 1:


### PR DESCRIPTION
Currently tifgenerator is dependent on preprocessing that happens in score_area.py -- now tifgenerator can be used stand-alone if need be to create tifs from scoring functions not in score_area.py